### PR TITLE
#31061 Updated packaging.

### DIFF
--- a/eng/Packaging.props
+++ b/eng/Packaging.props
@@ -6,13 +6,15 @@
     <PropertyGroup>
         <Authors>PostSharp Technologies</Authors>
         <PackageProjectUrl>https://github.com/postsharp/Metalama.Open.Costura</PackageProjectUrl>
-        <PackageTags></PackageTags>
+        <PackageTags>PostSharp Metalama AOP</PackageTags>
         <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
         <PackageLicenseFile>LICENSE.md</PackageLicenseFile>
+		<PackageReadmeFile>README.md</PackageReadmeFile>
     </PropertyGroup>
 
     <!-- Additional content of NuGet packages -->
     <ItemGroup>
+		<None Include="$(MSBuildThisFileDirectory)..\README.md" Visible="false" Pack="true" PackagePath="" />
         <None Include="$(MSBuildThisFileDirectory)..\LICENSE.md" Visible="false" Pack="true" PackagePath="" />
     </ItemGroup>
 

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -10,8 +10,8 @@
 
     <!-- Set the default versions of dependencies -->
     <PropertyGroup>
-        <PostSharpEngineeringVersion>1.0.94-preview</PostSharpEngineeringVersion>
-		<MetalamaVersion>0.5.38-preview</MetalamaVersion>
+        <PostSharpEngineeringVersion>1.0.96-preview</PostSharpEngineeringVersion>
+		<MetalamaVersion>0.5.46-preview</MetalamaVersion>
 		<MetalamaVersion Condition="$(VcsBranch.StartsWith('dev'))">branch:master</MetalamaVersion>
 
         <NewtonsoftJsonVersion>13.0.1</NewtonsoftJsonVersion>

--- a/global.json
+++ b/global.json
@@ -4,6 +4,6 @@
     "rollForward": "major"
   },
   "msbuild-sdks": {
-    "PostSharp.Engineering.Sdk": "1.0.94-preview"
+    "PostSharp.Engineering.Sdk": "1.0.96-preview"
   }
 }

--- a/src/Metalama.Open.Costura.Weaver/Metalama.Open.Costura.Weaver.csproj
+++ b/src/Metalama.Open.Costura.Weaver/Metalama.Open.Costura.Weaver.csproj
@@ -3,6 +3,7 @@
     <PropertyGroup>
         <TargetFramework>netstandard2.0</TargetFramework>
         <PackageId>Metalama.Open.Costura</PackageId>
+		<PackageDescription>A Metalama weaver that embeds dependent assemblies as managed resources. A fork of Costura.Fody.</PackageDescription>
     </PropertyGroup>
 
     <ItemGroup>


### PR DESCRIPTION
Updated NuGet package contents:
- New Metalama icon (yellow stripes, transparent background)
- README file and package descriptions added to `Metalama.Open.Costura` package.